### PR TITLE
feat: add EVRO stats endpoint

### DIFF
--- a/frontend/app/src/abi/StabilityPool.ts
+++ b/frontend/app/src/abi/StabilityPool.ts
@@ -147,7 +147,7 @@ export const StabilityPool = [
   },
   {
     "type": "function",
-    "name": "getTotalBoldDeposits",
+    "name": "getTotalEvroDeposits",
     "inputs": [],
     "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
     "stateMutability": "view",

--- a/frontend/app/src/liquity-utils.ts
+++ b/frontend/app/src/liquity-utils.ts
@@ -167,10 +167,12 @@ export type BoldYield = {
 };
 
 export function useBoldYieldSources() {
-  const { data, isLoading, error } = useLiquityStats();
+  const { /* data, */ isLoading, error } = useLiquityStats();
 
   return {
-    data: data?.boldYield as BoldYield[],
+    // data: data?.boldYield as BoldYield[],
+    // TODO: This is not being used, so we are returning an empty array for now
+    data: [] as BoldYield[],
     isLoading,
     error,
   };
@@ -204,15 +206,15 @@ export function useEarnPool(branchId: BranchId | null) {
       if (branchId === null) {
         return null;
       }
-      const totalBoldDeposits = await readContract(wagmiConfig, {
+      const totalEvroDeposits = await readContract(wagmiConfig, {
         ...getBranchContract(branchId, "StabilityPool"),
-        functionName: "getTotalBoldDeposits",
+        functionName: "getTotalEvroDeposits",
       });
       return {
         apr: spApyAvg1d,
         apr7d: spApyAvg7d,
         collateral,
-        totalDeposited: dnum18(totalBoldDeposits),
+        totalDeposited: dnum18(totalEvroDeposits),
       };
     },
     enabled: stats.isSuccess,
@@ -244,7 +246,7 @@ export function useEarnPools(branchIds: (BranchId | null)[]) {
           try {
             const totalBoldDeposits = await readContract(wagmiConfig, {
               ...getBranchContract(branchId, "StabilityPool"),
-              functionName: "getTotalBoldDeposits",
+              functionName: "getTotalEvroDeposits",
             });
             
             poolsMap[branchId] = {
@@ -722,15 +724,7 @@ export async function getTroveOperationHints({
   return { upperHint, lowerHint };
 }
 
-const BoldYieldItem = v.object({
-  asset: v.string(),
-  weekly_apr: v.union([v.number(), v.string()]),
-  tvl: v.union([v.number(), v.string()]),
-  link: v.string(),
-  protocol: v.string(),
-});
-
-export const StatsSchema = v.pipe(
+const StatsSchema = v.pipe(
   v.object({
     total_bold_supply: v.string(),
     total_debt_pending: v.string(),
@@ -738,16 +732,6 @@ export const StatsSchema = v.pipe(
     total_sp_deposits: v.string(),
     total_value_locked: v.string(),
     max_sp_apy: v.string(),
-    prices: v.record(
-      v.string(),
-      v.string(),
-    ),
-    boldYield: v.optional(v.nullable(v.array(BoldYieldItem))),
-    // TODO: phase out in the future, once all frontends update to the "safe" (losely-typed) `prices` schema
-    otherPrices: v.optional(v.record(
-      v.string(),
-      v.string(),
-    )),
     branch: v.record(
       v.string(),
       v.object({
@@ -795,23 +779,6 @@ export const StatsSchema = v.pipe(
         }];
       }),
     ),
-    prices: Object.fromEntries(
-      [
-        ...Object.entries(value.prices),
-        // TODO: phase out in the future, once all frontends update to the "safe" (losely-typed) `prices` schema
-        ...Object.entries(value.otherPrices ?? {}),
-      ].map(([symbol, price]) => [
-        symbol,
-        dnumOrNull(price, 18),
-      ]),
-    ),
-    boldYield: (value.boldYield ?? []).map((i) => ({
-      asset: i.asset,
-      weeklyApr: dnumOrNull(i.weekly_apr, 18),
-      tvl: dnumOrNull(i.tvl, 18),
-      link: i.link,
-      protocol: i.protocol,
-    })),
   })),
 );
 


### PR DESCRIPTION
This pull request primarily updates the naming and handling of deposit-related functions and data, and removes unused code related to yield sources. The main focus is on renaming "Bold" deposits to "Evro" deposits in both ABI and application logic, and simplifying the stats schema by removing yield-related structures.

**Renaming and Consistency Updates:**

* Renamed the function in the StabilityPool ABI from `getTotalBoldDeposits` to `getTotalEvroDeposits` to reflect updated terminology.
* Updated all references in the codebase (`useEarnPool`, `useEarnPools`) to use the new `getTotalEvroDeposits` function name and variable naming for consistency. [[1]](diffhunk://#diff-20726b3dff6d8c9c909e42d9892eb767c60e7908d293aa1bd6b2d09de67de6f5L207-R217) [[2]](diffhunk://#diff-20726b3dff6d8c9c909e42d9892eb767c60e7908d293aa1bd6b2d09de67de6f5L247-R249)

**Removal of Unused Yield-Related Code:**

* Removed the `BoldYieldItem` schema and all related yield processing from the stats schema, as this data is no longer used. [[1]](diffhunk://#diff-20726b3dff6d8c9c909e42d9892eb767c60e7908d293aa1bd6b2d09de67de6f5L725-L750) [[2]](diffhunk://#diff-20726b3dff6d8c9c909e42d9892eb767c60e7908d293aa1bd6b2d09de67de6f5L798-L814)
* Modified the `useBoldYieldSources` hook to return an empty array and commented out unused data extraction, with a note for future cleanup.

These changes help ensure the codebase uses consistent terminology and eliminates unused or outdated logic.