### PR TITLE
fix: add variant collateral symbols to earn row

### DIFF
--- a/frontend/app/src/liquity-utils.ts
+++ b/frontend/app/src/liquity-utils.ts
@@ -191,8 +191,10 @@ export function useEarnPool(branchId: BranchId | null) {
   const wagmiConfig = useWagmiConfig();
   const stats = useLiquityStats();
   const collateral = getCollToken(branchId);
+  const collateralSymbolVariant = collateral?.symbol === "XDAI" ? "WXDAI" : collateral?.symbol === "WBTC" ? "WWBTC" : collateral?.symbol;
+
   const { spApyAvg1d = null, spApyAvg7d = null } = (
-    collateral && stats.data?.branch[collateral?.symbol]
+    collateral && stats.data?.branch[collateralSymbolVariant]
   ) ?? {};
 
   return useQuery({
@@ -239,8 +241,10 @@ export function useEarnPools(branchIds: (BranchId | null)[]) {
           if (branchId === null) return;
           
           const collateral = getCollToken(branchId);
+          const collateralSymbolVariant = collateral?.symbol === "XDAI" ? "WXDAI" : collateral?.symbol === "WBTC" ? "WWBTC" : collateral?.symbol;
+
           const { spApyAvg1d = null, spApyAvg7d = null } = (
-            collateral && stats.data?.branch[collateral?.symbol]
+            collateral && stats.data?.branch[collateralSymbolVariant]
           ) ?? {};
           
           try {


### PR DESCRIPTION
This pull request updates how collateral symbols are handled when fetching statistics for earn pools. The main improvement is ensuring that the correct variant of the collateral symbol is used to match the keys in the statistics data, which helps avoid mismatches for certain tokens.

**Handling of collateral symbol variants:**

* Updated both `useEarnPool` and `useEarnPools` hooks in `liquity-utils.ts` to map `"XDAI"` to `"WXDAI"` and `"WBTC"` to `"WWBTC"` when accessing statistics data, ensuring correct data retrieval. [[1]](diffhunk://#diff-20726b3dff6d8c9c909e42d9892eb767c60e7908d293aa1bd6b2d09de67de6f5R194-R197) [[2]](diffhunk://#diff-20726b3dff6d8c9c909e42d9892eb767c60e7908d293aa1bd6b2d09de67de6f5R244-R247)